### PR TITLE
Add unit tests (jtalk text processing) and CI workflow

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,0 +1,250 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section('parse'):
+    # Specify structure for custom cmake functions
+    additional_commands = {
+        # 'find_package': {
+        #     'kwargs': {
+        #         'COMPONENTS': '*'}},
+        'add_message_files': {'kwargs': {'FILES': '*'}},
+        'add_service_files': {'kwargs': {'FILES': '*'}},
+        'add_action_files': {'kwargs': {'FILES': '*'}},
+        'generate_messages': {'kwargs': {'DEPENDENCIES': '*'}},
+        'catkin_package': {
+            'kwargs': {
+                'INCLUDE_DIRS': '*',
+                'LIBRARIES': '*',
+                'CATKIN_DEPENDS': '*',
+                'DEPENDS': '*',
+            }
+        },
+        'catkin_install_python': {'kwargs': {'PROGRAMS': '*', 'DESTINATION': '*'}},
+    }
+
+    # Override configurations per-command where available
+    override_spec = {}
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section('format'):
+    # Disable formatting entirely, making cmake-format a no-op
+    disable = False
+
+    # How wide to allow formatted cmake files
+    line_width = 120
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If true, lines are indented using tab characters (utf-8 0x09) instead of
+    # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+    # require a fractional tab character, the behavior of the  fractional
+    # indentation is governed by <fractional_tab_policy>
+    use_tabchars = False
+
+    # If <use_tabchars> is True, then the value of this variable indicates how
+    # fractional indentions are handled during whitespace replacement. If set to
+    # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+    # to `round-up` fractional indentation is replaced with a single tab character
+    # (utf-8 0x09) effectively shifting the column to the next tabstop
+    fractional_tab_policy = 'use-space'
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg
+    # groups) then force it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then
+    # force it to a vertical layout.
+    max_pargs_hwrap = 2
+
+    # If a cmdline positional group consumes more than this many lines without
+    # nesting, then invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = 'prefix'
+
+    # If the statement spelling length (including space and parenthesis) is
+    # smaller than this amount, then force reject nested layouts.
+    min_prefix_chars = 0
+
+    # If the statement spelling length (including space and parenthesis) is larger
+    # than the tab width by more than this amount, then force reject un-nested
+    # layouts.
+    max_prefix_chars = 0
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many
+    # lines, then reject the layout.
+    max_lines_hwrap = 0
+
+    # What style line endings to use in the output.
+    line_ending = 'unix'
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = 'canonical'
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = 'unchanged'
+
+    # A list of command names which should always be wrapped
+    always_wrap = ['install', 'catkin_install_python']
+
+    # If true, the argument lists which are known to be sortable will be sorted
+    # lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable
+    # (without annotation).
+    autosort = False
+
+    # By default, if cmake-format cannot successfully fit everything into the
+    # desired linewidth it will apply the last, most agressive attempt that it
+    # made. If this flag is True, however, cmake-format will print error, exit
+    # with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the
+    # documentation for more information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section('markup'):
+    # What character to use for bulleted lists
+    bullet_char = '*'
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = '.'
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = False
+
+    # If comment markup is enabled, don't reflow any comment block which matches
+    # this (regex) pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = '^\\s*([`~]{3}[`~]*)(.*)$'
+
+    # Regular expression to match rulers in comments default=
+    # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+
+    # If a comment line matches starts with this pattern then it is explicitly a
+    # trailing comment for the preceeding argument. Default is '#<'
+    explicit_trailing_pattern = '#<'
+
+    # If a comment line starts with at least this many consecutive hash
+    # characters, then don't lstrip() them off. This allows for lazy hash rulers
+    # where the first hash char is not separated by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash
+    # chars in a hash ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = False
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section('lint'):
+    # a list of lint codes to disable
+    disabled_codes = []
+
+    # regular expression pattern describing valid function names
+    function_pattern = '[0-9a-z_]+'
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = '[0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # (cache) scope
+    global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # scope (but internal semantic)
+    internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with local
+    # scope
+    local_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for privatedirectory
+    # variables
+    private_var_pattern = '_[0-9a-z_]+'
+
+    # regular expression pattern describing valid names for public directory
+    # variables
+    public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for function/macro
+    # arguments and loop variables.
+    argument_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for keywords used in
+    # functions or macros
+    keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in
+    # before considering the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section('encode'):
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = 'utf-8'
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+    # only claims to support utf-8 so be careful when using anything else
+    output_encoding = 'utf-8'
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section('misc'):
+    # A dictionary containing any per-command configuration overrides. Currently
+    # only `command_case` is supported.
+    per_command = {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest beartype
+        run: pip install pytest beartype pyyaml
       - name: Run unit tests
-        run: python -m pytest cube_petit_text_to_speech/test cube_petit_python_api/test -v
+        run: python -m pytest cube_petit_text_to_speech/test cube_petit_python_api/test cube_petit_bringup/test -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Install test dependencies
         run: pip install pytest beartype
       - name: Run unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches: [jazzy-devel]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  linter:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Linter
+    uses: sbgisen/.github/.github/workflows/ros2_style.yaml@main
+  build:
+    needs: linter
+    if: ${{ !failure() }}
+    name: Build
+    uses: sbgisen/.github/.github/workflows/ros2-build.yml@main
+    with:
+      ros_distro: jazzy
+    secrets:
+      ssh_key: ${{ secrets.GISEN_ROBO_GIT }}
+      known_hosts: ${{ secrets.KNOWN_HOSTS }}
+  release-drafter:
+    name: Release drafter
+    uses: sbgisen/.github/.github/workflows/release-drafter.yml@main
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: pip install pytest beartype
+      - name: Run unit tests
+        run: python -m pytest cube_petit_text_to_speech/test cube_petit_python_api/test -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+---
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--disable-plugin", "KeywordDetector"]
+        exclude: package.lock.json
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args:
+          - "--fix=lf"
+        description: Forces to replace line ending by the UNIX 'lf' character.
+      - id: end-of-file-fixer
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--sp", "./pyproject.toml", "--src", "."]
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      - id: yapf
+        args: [-ip, --style, ./pyproject.toml]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff
+        args: [--config, ./pyproject.toml]
+  - repo: git@github.com:sbgisen/pre-commit-hooks.git
+    rev: v1.1.4
+    hooks:
+      - id: yamlfixer
+        args: [-c, ./.yamllint]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args:
+          - "-s"
+          - "-c"
+          - "./.yamllint"
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        args: [-c, ./.cmake-format, --in-place]
+  - repo: git@github.com:sbgisen/pre-commit-hooks.git
+    rev: v1.1.4
+    hooks:
+      - id: package_lint
+        name: check package.xml schema
+  - repo: git@github.com:sbgisen/pre-commit-hooks.git
+    rev: v1.1.4
+    hooks:
+      - id: xmllint
+        name: xml format
+        args:
+          - "-i"
+          - "--format"
+          - "--ignore-empty"
+        types_or:
+          - "file"
+        files: ^.*\.(launch|xml|xacro|urdf)$

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,18 @@
+extends: default
+
+rules:
+  document-end: disable
+  document-start: disable
+  truthy: disable
+  line-length:
+    max: 120
+  indentation:
+    spaces: 2
+  braces:
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+  quoted-strings:
+    quote-type: double
+    required: false
+  comments:
+    min-spaces-from-content: 1

--- a/cube_petit_bringup/package.xml
+++ b/cube_petit_bringup/package.xml
@@ -20,6 +20,9 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>cube_petit_speech_msgs</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/cube_petit_bringup/setup.cfg
+++ b/cube_petit_bringup/setup.cfg
@@ -2,3 +2,5 @@
 script_dir=$base/lib/cube_petit_bringup
 [install]
 install_scripts=$base/lib/cube_petit_bringup
+[tool:pytest]
+testpaths = test

--- a/cube_petit_bringup/setup.py
+++ b/cube_petit_bringup/setup.py
@@ -25,6 +25,7 @@ setup(
     maintainer_email="SBGRP-git@g.softbank.co.jp",
     description="cube_petit bringup package",
     license="Apache License 2.0",
+    tests_require=["pytest"],
     entry_points={
         "console_scripts": [
             "startup_announcer = cube_petit_bringup.startup_announcer:main",

--- a/cube_petit_bringup/setup.py
+++ b/cube_petit_bringup/setup.py
@@ -1,34 +1,44 @@
 #!/usr/bin/env python
+# -*- coding:utf-8 -*-
 
 # Copyright (c) 2026 SoftBank Corp.
-# 
-# <<licensetext>>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from setuptools import setup
 import glob
 
-package_name = "cube_petit_bringup"
+from setuptools import setup
+
+package_name = 'cube_petit_bringup'
 
 setup(
     name=package_name,
-    version="0.0.0",
+    version='0.0.0',
     packages=[package_name],
     data_files=[
-        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
-        (f"share/{package_name}", ["package.xml"]),
-        (f"share/{package_name}/launch", glob.glob("launch/*.launch.py")),
-        (f"share/{package_name}/config", glob.glob("config/*")),
+        ('share/ament_index/resource_index/packages', [f'resource/{package_name}']),
+        (f'share/{package_name}', ['package.xml']),
+        (f'share/{package_name}/launch', glob.glob('launch/*.launch.py')),
+        (f'share/{package_name}/config', glob.glob('config/*')),
     ],
-    install_requires=["setuptools"],
+    install_requires=['setuptools'],
     zip_safe=True,
-    maintainer="gisen",
-    maintainer_email="SBGRP-git@g.softbank.co.jp",
-    description="cube_petit bringup package",
-    license="Apache License 2.0",
-    tests_require=["pytest"],
+    maintainer='gisen',
+    maintainer_email='SBGRP-git@g.softbank.co.jp',
+    description='cube_petit bringup package',
+    license='Apache License 2.0',
+    tests_require=['pytest'],
     entry_points={
-        "console_scripts": [
-            "startup_announcer = cube_petit_bringup.startup_announcer:main",
-        ],
+        'console_scripts': ['startup_announcer = cube_petit_bringup.startup_announcer:main',],
     },
 )

--- a/cube_petit_bringup/test/test_config_files.py
+++ b/cube_petit_bringup/test/test_config_files.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sanity tests for config and launch files (no ROS environment required)."""
+
+from pathlib import Path
+import py_compile
+
+import pytest
+import yaml
+
+PACKAGE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_YAML_FILES = sorted((PACKAGE_DIR / 'config').glob('*.yaml'))
+LAUNCH_PY_FILES = sorted((PACKAGE_DIR / 'launch').glob('*.launch.py'))
+
+
+def test_config_yaml_files_exist() -> None:
+    """The package should ship at least one config/*.yaml file."""
+    assert CONFIG_YAML_FILES, f'No *.yaml files found under {PACKAGE_DIR / "config"}'
+
+
+def test_launch_py_files_exist() -> None:
+    """The package should ship at least one launch/*.launch.py file."""
+    assert LAUNCH_PY_FILES, f'No *.launch.py files found under {PACKAGE_DIR / "launch"}'
+
+
+@pytest.mark.parametrize('yaml_path', CONFIG_YAML_FILES, ids=lambda p: p.name)
+def test_config_yaml_parses_and_is_non_empty(yaml_path: Path) -> None:
+    """Every config/*.yaml must parse as YAML and contain data."""
+    data = yaml.safe_load(yaml_path.read_text(encoding='utf-8'))
+    assert data is not None, f'{yaml_path.name} is empty'
+    assert data, f'{yaml_path.name} parsed to an empty value'
+
+
+@pytest.mark.parametrize('launch_path', LAUNCH_PY_FILES, ids=lambda p: p.name)
+def test_launch_py_compiles(launch_path: Path) -> None:
+    """Every launch/*.launch.py must be valid Python (byte-compilable)."""
+    py_compile.compile(str(launch_path), doraise=True)

--- a/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
+++ b/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
@@ -23,11 +23,12 @@ import pathlib
 import typing
 
 from ament_index_python.packages import get_package_share_directory
-from cube_petit_python_api.utils import gpt_logic
 import cv2
 import numpy as np
 import openai
 from rclpy.node import Node
+
+from cube_petit_python_api.utils import gpt_logic
 
 
 class GPTClient(object):

--- a/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
+++ b/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
@@ -15,20 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""GPT chat"""
+"""GPT chat."""
 
 import base64
 import os
 import pathlib
 import typing
 
+from ament_index_python.packages import get_package_share_directory
+from cube_petit_python_api.utils import gpt_logic
 import cv2
 import numpy as np
 import openai
-from ament_index_python.packages import get_package_share_directory
 from rclpy.node import Node
-
-from cube_petit_python_api.utils import gpt_logic
 
 
 class GPTClient(object):
@@ -40,22 +39,22 @@ class GPTClient(object):
                  model_name: str = 'gpt-4-turbo',
                  use_image: bool = False,
                  setting_file: typing.Optional[pathlib.Path] = None) -> None:
-        """Constructor.
+        """Initialize the client.
 
-            Args:
-                api_key: API key.
-                model_name: Name of the model to use.
-                setting_file: Settings text file path.
-                optical_setting_file: Optical Setting file.
-              """
-
+        Args:
+            node: ROS node used for logging.
+            api_key: API key.
+            model_name: Name of the model to use.
+            use_image: Whether to use image input.
+            setting_file: Settings text file path.
+        """
         self.node = node
-        if api_key is None or api_key == "":
-            if os.getenv('OPENAI_API_KEY', '') == "":
-                self.node.get_logger().error("No api_key...")
+        if api_key is None or api_key == '':
+            if os.getenv('OPENAI_API_KEY', '') == '':
+                self.node.get_logger().error('No api_key...')
                 # return False
             else:
-                self.node.get_logger().warn("Use env OPENAI_API_KEY")
+                self.node.get_logger().warn('Use env OPENAI_API_KEY')
 
         self.__model_name = model_name
 
@@ -71,23 +70,23 @@ class GPTClient(object):
 
     def get_response_use_image(self, input_text: str = None, image: np.ndarray = None, contexts: dict = None) -> str:
         if image is None:
-            self.node.get_logger().warn("use test image...")
+            self.node.get_logger().warn('use test image...')
             package_path = get_package_share_directory('cube_petit_python_api')
-            image_path = f"{package_path}/resource/cube_petit_cad.png"
+            image_path = f'{package_path}/resource/cube_petit_cad.png'
             image = cv2.imread(image_path)
             if image is None:
-                raise FileNotFoundError(f"Image not found at {image_path}")
+                raise FileNotFoundError(f'Image not found at {image_path}')
 
         _, bin_image = cv2.imencode('.png', image)
         base64_image = base64.b64encode(bin_image).decode('utf-8')
 
         if contexts is None:
             if input_text is None:
-                self.node.get_logger().error("No input_text")
+                self.node.get_logger().error('No input_text')
                 return False
             contexts = gpt_logic.build_image_contexts(self.__setting_file, input_text, base64_image)
         response = self.__client.chat.completions.create(
-            model="gpt-4-vision-preview",
+            model='gpt-4-vision-preview',
             messages=contexts,
             max_tokens=300,
         )
@@ -95,24 +94,24 @@ class GPTClient(object):
         return response.choices[0].message.content
 
     def get_response(self, input_text: str = None, contexts: dict = None) -> str:
-        """Sends request via Chat-GPT API.
+        """Send request via Chat-GPT API.
 
         Args:
             input_text: User input text.
+            contexts: Prebuilt message contexts. Built from input_text when omitted.
 
         Returns:
             Response message.
         """
         if contexts is None:
             if input_text is None:
-                self.node.get_logger().error("No input_text")
+                self.node.get_logger().error('No input_text')
                 return False
             contexts = gpt_logic.build_text_contexts(self.__setting_file, input_text)
-        result = self.__client.chat.completions.create(
-            model=self.__model_name,
-            response_format={'type': 'json_object'},
-            messages=contexts,
-            max_tokens=1000)
+        result = self.__client.chat.completions.create(model=self.__model_name,
+                                                       response_format={'type': 'json_object'},
+                                                       messages=contexts,
+                                                       max_tokens=1000)
         self.node.get_logger().info(result.choices[0].message.content)
 
         return result.choices[0].message.content

--- a/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
+++ b/cube_petit_python_api/cube_petit_python_api/utils/gpt_client.py
@@ -28,6 +28,8 @@ import openai
 from ament_index_python.packages import get_package_share_directory
 from rclpy.node import Node
 
+from cube_petit_python_api.utils import gpt_logic
+
 
 class GPTClient(object):
     """Chat GPT based chat bot class."""
@@ -60,8 +62,7 @@ class GPTClient(object):
         if setting_file is not None:
             self.__setting_file = setting_file
         else:
-            self.__setting_file = """
-                出力はjson形式で{"speech_phrase": ""}のように、speech_phraseの中に返答をいれて返してください"""
+            self.__setting_file = gpt_logic.DEFAULT_SETTING
 
         if not use_image:
             self.__client = openai.OpenAI(api_key=api_key)
@@ -84,15 +85,7 @@ class GPTClient(object):
             if input_text is None:
                 self.node.get_logger().error("No input_text")
                 return False
-            contexts = [
-                {"role": "system", "content": self.__setting_file},
-                {"role": "user",
-                 "content": [
-                     {"type": "text", "text": input_text},
-                     {"type": "image_url", "image_url": f"data:image/jpeg;base64,{base64_image}"},
-                 ],
-                 }
-            ]
+            contexts = gpt_logic.build_image_contexts(self.__setting_file, input_text, base64_image)
         response = self.__client.chat.completions.create(
             model="gpt-4-vision-preview",
             messages=contexts,
@@ -114,10 +107,7 @@ class GPTClient(object):
             if input_text is None:
                 self.node.get_logger().error("No input_text")
                 return False
-            contexts = [
-                {"role": "system", "content": self.__setting_file},
-                {"role": "user", "content": input_text}
-            ]
+            contexts = gpt_logic.build_text_contexts(self.__setting_file, input_text)
         result = self.__client.chat.completions.create(
             model=self.__model_name,
             response_format={'type': 'json_object'},

--- a/cube_petit_python_api/cube_petit_python_api/utils/gpt_logic.py
+++ b/cube_petit_python_api/cube_petit_python_api/utils/gpt_logic.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2024 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Pure (ROS-independent) helpers for building GPT chat requests."""
+
+DEFAULT_SETTING = """
+                出力はjson形式で{"speech_phrase": ""}のように、speech_phraseの中に返答をいれて返してください"""
+
+
+def build_text_contexts(setting: str, input_text: str) -> list:
+    """Build chat contexts for a text-only request.
+
+    Args:
+        setting: System prompt.
+        input_text: User input text.
+
+    Returns:
+        Message list for the Chat Completions API.
+    """
+    return [
+        {"role": "system", "content": setting},
+        {"role": "user", "content": input_text}
+    ]
+
+
+def build_image_contexts(setting: str, input_text: str, base64_image: str) -> list:
+    """Build chat contexts for a request that includes an image.
+
+    Args:
+        setting: System prompt.
+        input_text: User input text.
+        base64_image: Base64 encoded image.
+
+    Returns:
+        Message list for the Chat Completions API.
+    """
+    return [
+        {"role": "system", "content": setting},
+        {"role": "user",
+         "content": [
+             {"type": "text", "text": input_text},
+             {"type": "image_url", "image_url": f"data:image/jpeg;base64,{base64_image}"},
+         ],
+         }
+    ]

--- a/cube_petit_python_api/cube_petit_python_api/utils/gpt_logic.py
+++ b/cube_petit_python_api/cube_petit_python_api/utils/gpt_logic.py
@@ -31,10 +31,7 @@ def build_text_contexts(setting: str, input_text: str) -> list:
     Returns:
         Message list for the Chat Completions API.
     """
-    return [
-        {"role": "system", "content": setting},
-        {"role": "user", "content": input_text}
-    ]
+    return [{'role': 'system', 'content': setting}, {'role': 'user', 'content': input_text}]
 
 
 def build_image_contexts(setting: str, input_text: str, base64_image: str) -> list:
@@ -48,12 +45,20 @@ def build_image_contexts(setting: str, input_text: str, base64_image: str) -> li
     Returns:
         Message list for the Chat Completions API.
     """
-    return [
-        {"role": "system", "content": setting},
-        {"role": "user",
-         "content": [
-             {"type": "text", "text": input_text},
-             {"type": "image_url", "image_url": f"data:image/jpeg;base64,{base64_image}"},
-         ],
-         }
-    ]
+    return [{
+        'role': 'system',
+        'content': setting
+    }, {
+        'role':
+            'user',
+        'content': [
+            {
+                'type': 'text',
+                'text': input_text
+            },
+            {
+                'type': 'image_url',
+                'image_url': f'data:image/jpeg;base64,{base64_image}'
+            },
+        ],
+    }]

--- a/cube_petit_python_api/package.xml
+++ b/cube_petit_python_api/package.xml
@@ -10,6 +10,7 @@
   <depend>action_msgs</depend>
   <depend>actionlib_msgs</depend>
   <test_depend>actionlib_tutorials</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <!-- <depend>actionlib</depend>
   <depend>actionlib_msgs</depend>
   <depend>dynamic_reconfigure</depend>

--- a/cube_petit_python_api/setup.cfg
+++ b/cube_petit_python_api/setup.cfg
@@ -2,3 +2,5 @@
 script_dir=$base/lib/cube_petit_python_api
 [install]
 install_scripts=$base/lib/cube_petit_python_api
+[tool:pytest]
+testpaths = test

--- a/cube_petit_python_api/test/conftest.py
+++ b/cube_petit_python_api/test/conftest.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Make gpt_logic importable without installing the package.
+
+Note: the utils directory itself is added to sys.path because
+``cube_petit_python_api/__init__.py`` imports ROS dependencies at module
+level; importing via the package path would require a ROS environment.
+"""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'cube_petit_python_api' / 'utils'))

--- a/cube_petit_python_api/test/test_gpt_logic.py
+++ b/cube_petit_python_api/test/test_gpt_logic.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for gpt_logic (no ROS environment required)."""
+
+import gpt_logic
+
+
+class TestDefaultSetting:
+    """Tests for the default system prompt."""
+
+    def test_default_setting_mentions_json_key(self) -> None:
+        assert 'speech_phrase' in gpt_logic.DEFAULT_SETTING
+        assert 'json' in gpt_logic.DEFAULT_SETTING
+
+
+class TestBuildTextContexts:
+    """Tests for build_text_contexts()."""
+
+    def test_structure(self) -> None:
+        contexts = gpt_logic.build_text_contexts('system prompt', 'こんにちは')
+        assert contexts == [
+            {'role': 'system', 'content': 'system prompt'},
+            {'role': 'user', 'content': 'こんにちは'},
+        ]
+
+    def test_default_setting_is_usable_as_system_prompt(self) -> None:
+        contexts = gpt_logic.build_text_contexts(gpt_logic.DEFAULT_SETTING, 'hi')
+        assert contexts[0]['role'] == 'system'
+        assert contexts[0]['content'] == gpt_logic.DEFAULT_SETTING
+
+
+class TestBuildImageContexts:
+    """Tests for build_image_contexts()."""
+
+    def test_structure(self) -> None:
+        contexts = gpt_logic.build_image_contexts('system prompt', '何が見える?', 'QUJD')
+        assert len(contexts) == 2
+        assert contexts[0] == {'role': 'system', 'content': 'system prompt'}
+        user = contexts[1]
+        assert user['role'] == 'user'
+        assert user['content'][0] == {'type': 'text', 'text': '何が見える?'}
+        assert user['content'][1] == {'type': 'image_url', 'image_url': 'data:image/jpeg;base64,QUJD'}
+
+    def test_image_is_embedded_as_data_uri(self) -> None:
+        contexts = gpt_logic.build_image_contexts('s', 't', 'abc123==')
+        image_url = contexts[1]['content'][1]['image_url']
+        assert image_url.startswith('data:image/jpeg;base64,')
+        assert image_url.endswith('abc123==')

--- a/cube_petit_python_api/test/test_gpt_logic.py
+++ b/cube_petit_python_api/test/test_gpt_logic.py
@@ -33,8 +33,14 @@ class TestBuildTextContexts:
     def test_structure(self) -> None:
         contexts = gpt_logic.build_text_contexts('system prompt', 'こんにちは')
         assert contexts == [
-            {'role': 'system', 'content': 'system prompt'},
-            {'role': 'user', 'content': 'こんにちは'},
+            {
+                'role': 'system',
+                'content': 'system prompt'
+            },
+            {
+                'role': 'user',
+                'content': 'こんにちは'
+            },
         ]
 
     def test_default_setting_is_usable_as_system_prompt(self) -> None:

--- a/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
+++ b/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
@@ -18,6 +18,11 @@ import threading
 import time
 
 from action_msgs.msg import GoalStatus
+from cube_petit_speech_msgs.action import Speech
+from cube_petit_speech_msgs.msg import AudioDataStamped
+from cube_petit_speech_msgs.msg import AudioInfo
+from cube_petit_text_to_speech.utils.jtalk import check_goal
+from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_file
 import numpy as np
 import rclpy
 from rclpy.action import ActionServer
@@ -31,12 +36,6 @@ from rclpy.qos import QoSProfile
 from scipy.signal import resample_poly
 import sounddevice as sd
 import soundfile as sf
-
-from cube_petit_speech_msgs.action import Speech
-from cube_petit_speech_msgs.msg import AudioDataStamped
-from cube_petit_speech_msgs.msg import AudioInfo
-from cube_petit_text_to_speech.utils.jtalk import check_goal
-from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_file
 
 
 class SpeechActionServer(Node):

--- a/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
+++ b/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
@@ -92,7 +92,9 @@ class SpeechActionServer(Node):
 
         try:
             res = Speech.Result()
-            if not check_goal(goal_handle.request):
+            request = goal_handle.request
+            if not check_goal(request.text, request.emotion, request.emotion_level, request.pitch, request.speed,
+                              request.volume):
                 self.get_logger().error('Invalid speech goal received.')
                 goal_handle.abort()
                 res.result = False

--- a/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
+++ b/cube_petit_text_to_speech/cube_petit_text_to_speech/speech_action_server.py
@@ -18,11 +18,6 @@ import threading
 import time
 
 from action_msgs.msg import GoalStatus
-from cube_petit_speech_msgs.action import Speech
-from cube_petit_speech_msgs.msg import AudioDataStamped
-from cube_petit_speech_msgs.msg import AudioInfo
-from cube_petit_text_to_speech.utils.jtalk import check_goal
-from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_file
 import numpy as np
 import rclpy
 from rclpy.action import ActionServer
@@ -36,6 +31,12 @@ from rclpy.qos import QoSProfile
 from scipy.signal import resample_poly
 import sounddevice as sd
 import soundfile as sf
+
+from cube_petit_speech_msgs.action import Speech
+from cube_petit_speech_msgs.msg import AudioDataStamped
+from cube_petit_speech_msgs.msg import AudioInfo
+from cube_petit_text_to_speech.utils.jtalk import check_goal
+from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_file
 
 
 class SpeechActionServer(Node):

--- a/cube_petit_text_to_speech/cube_petit_text_to_speech/utils/jtalk.py
+++ b/cube_petit_text_to_speech/cube_petit_text_to_speech/utils/jtalk.py
@@ -14,23 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import pathlib
 import re
 import subprocess
 import sys
 
-from ament_index_python import get_package_share_directory
 from beartype import beartype
 
-from cube_petit_speech_msgs.action import Speech
-
-__all__ = ['LIB_ROUTE', 'simple_jtalk', 'generate_jtalk_command', 'adjust_text']
-
-# Jtalk Library Path
-LIB_ROUTE = f'{get_package_share_directory("cube_petit_text_to_speech")}/speech_lib/'
+__all__ = ['LIB_ROUTE', 'simple_jtalk', 'generate_jtalk_command', 'adjust_text']  # noqa: F822 (LIB_ROUTE is lazy)
 
 OUTPUT_FILE = pathlib.Path('/tmp/jtalk_output.wav')
+
+
+@functools.lru_cache(maxsize=1)
+def _lib_route() -> str:
+    """Return the jtalk library path lazily (requires a ROS environment)."""
+    from ament_index_python import get_package_share_directory
+    return f'{get_package_share_directory("cube_petit_text_to_speech")}/speech_lib/'
+
+
+def __getattr__(name: str) -> str:
+    """Provide the legacy module-level ``LIB_ROUTE`` constant lazily."""
+    if name == 'LIB_ROUTE':
+        return _lib_route()
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 @beartype
@@ -42,6 +51,7 @@ def simple_jtalk(text: str) -> None:
     """
     if text == '':
         return
+    from cube_petit_speech_msgs.action import Speech
     generate_jtalk_file(text, Speech.Goal.EMOTION_DEFAULT, 100, 100)
     subprocess.Popen(generate_jtalk_command(OUTPUT_FILE),
                      stdin=subprocess.PIPE,
@@ -51,20 +61,33 @@ def simple_jtalk(text: str) -> None:
 
 
 @beartype
-def check_goal(goal: Speech.Goal) -> bool:
+def check_goal(text: str, emotion: str, emotion_level: int, pitch: int, speed: int, volume: int) -> bool:
+    """Validate speech goal values.
+
+    Args:
+        text: Phrase to be said.
+        emotion: Emotion of the phrase to be played.
+        emotion_level: Emotion level. Value between 1 and 5.
+        pitch: Pitch of the phrase to be played. Value between 50 and 199.
+        speed: Speed of the phrase to be played. Value between 50 and 299.
+        volume: Volume of the phrase to be played. Value between 1 and 100.
+
+    Returns:
+        True if all the values are valid.
+    """
     # text
-    if not goal.text:
+    if not text:
         return False
     valid_emotions = {'happy', 'normal', 'angry', 'bashful', 'sad'}
-    if goal.emotion not in valid_emotions:
+    if emotion not in valid_emotions:
         return False
-    if not (1 <= goal.emotion_level <= 5):
+    if not (1 <= emotion_level <= 5):
         return False
-    if not (50 <= goal.pitch < 200):
+    if not (50 <= pitch < 200):
         return False
-    if not (50 <= goal.speed < 300):
+    if not (50 <= speed < 300):
         return False
-    if not (1 <= goal.volume <= 100):
+    if not (1 <= volume <= 100):
         return False
 
     return True
@@ -88,11 +111,12 @@ def generate_jtalk_file(text: str,
     Returns:
         Path to the generated audio file.
     """
+    lib_route = _lib_route()
     text = adjust_text(text)
     echo = f'echo {text} | '
-    open_jtalk = f'{LIB_ROUTE}open_jtalk-1.11/bin/open_jtalk '
-    dic = f'-x {LIB_ROUTE}open_jtalk_dic_utf_8-1.11 '
-    htsvoice = f'-m {LIB_ROUTE}MMDAgent_Example-1.6/Voice/mei/mei_{emotion}.htsvoice '
+    open_jtalk = f'{lib_route}open_jtalk-1.11/bin/open_jtalk '
+    dic = f'-x {lib_route}open_jtalk_dic_utf_8-1.11 '
+    htsvoice = f'-m {lib_route}MMDAgent_Example-1.6/Voice/mei/mei_{emotion}.htsvoice '
     speed_param = f'-r {float(speed) / 100} '
     intonation = f'-jf {float(pitch) / 100} '
     if file_path is None:

--- a/cube_petit_text_to_speech/test/conftest.py
+++ b/cube_petit_text_to_speech/test/conftest.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Make the package importable without installing it."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/cube_petit_text_to_speech/test/test_jtalk.py
+++ b/cube_petit_text_to_speech/test/test_jtalk.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for cube_petit_text_to_speech.utils.jtalk (no ROS environment required)."""
+
+import pathlib
+
+import pytest
+
+from cube_petit_text_to_speech.utils import jtalk
+from cube_petit_text_to_speech.utils.jtalk import adjust_text
+from cube_petit_text_to_speech.utils.jtalk import check_goal
+from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_command
+
+SUFFIX = '〜っ、。'
+
+
+class TestAdjustText:
+    """Tests for adjust_text()."""
+
+    def test_empty_string_gets_only_suffix(self) -> None:
+        assert adjust_text('') == SUFFIX
+
+    def test_plain_japanese_text_is_kept(self) -> None:
+        assert adjust_text('こんにちは') == 'こんにちは' + SUFFIX
+
+    def test_half_width_space_becomes_comma(self) -> None:
+        assert adjust_text('a b') == 'a、b' + SUFFIX
+
+    def test_full_width_space_becomes_comma(self) -> None:
+        assert adjust_text('あ　い') == 'あ、い' + SUFFIX
+
+    def test_newline_becomes_period(self) -> None:
+        assert adjust_text('あ\nい') == 'あ。い' + SUFFIX
+
+    def test_repeat_mark_becomes_long_vowel(self) -> None:
+        assert adjust_text('ゝ') == 'ー、' + SUFFIX
+
+    def test_corner_brackets_become_commas(self) -> None:
+        assert adjust_text('「こんにちは」') == '、こんにちは、' + SUFFIX
+
+    def test_full_width_exclamation_mark(self) -> None:
+        assert adjust_text('！') == 'っ。' + SUFFIX
+
+    def test_half_width_exclamation_mark(self) -> None:
+        assert adjust_text('Hello!') == 'Helloっ。' + SUFFIX
+
+    def test_periods_and_commas_are_normalized(self) -> None:
+        assert adjust_text('．，') == '。、' + SUFFIX
+
+    def test_half_width_period_between_digits(self) -> None:
+        assert adjust_text('1.5') == '1。5' + SUFFIX
+
+    def test_ascii_letters_and_digits_are_kept(self) -> None:
+        assert adjust_text('数字123') == '数字123' + SUFFIX
+
+    def test_half_width_symbol_becomes_comma(self) -> None:
+        assert adjust_text('#') == '、' + SUFFIX
+
+    def test_full_width_digits_become_commas(self) -> None:
+        assert adjust_text('１２３') == '、、、' + SUFFIX
+
+    def test_duplicated_periods_are_collapsed(self) -> None:
+        assert adjust_text('。。') == '。' + SUFFIX
+
+    def test_period_followed_by_space_is_collapsed(self) -> None:
+        assert adjust_text('おはよう。 ') == 'おはよう。' + SUFFIX
+
+    def test_horizontal_bar_is_removed(self) -> None:
+        assert adjust_text('―') == SUFFIX
+
+    def test_mixed_sentence(self) -> None:
+        assert adjust_text('Hello, world!') == 'Hello、、worldっ。' + SUFFIX
+
+    def test_non_string_input_is_rejected(self) -> None:
+        with pytest.raises(Exception):
+            adjust_text(123)
+
+
+class TestCheckGoal:
+    """Tests for check_goal()."""
+
+    def test_valid_goal(self) -> None:
+        assert check_goal('こんにちは', 'happy', 3, 100, 100, 50) is True
+
+    @pytest.mark.parametrize('emotion', ['happy', 'normal', 'angry', 'bashful', 'sad'])
+    def test_all_valid_emotions(self, emotion: str) -> None:
+        assert check_goal('hi', emotion, 1, 50, 50, 1) is True
+
+    def test_empty_text_is_invalid(self) -> None:
+        assert check_goal('', 'happy', 3, 100, 100, 50) is False
+
+    @pytest.mark.parametrize('emotion', ['', 'default', 'happiness', 'HAPPY'])
+    def test_unknown_emotion_is_invalid(self, emotion: str) -> None:
+        assert check_goal('hi', emotion, 3, 100, 100, 50) is False
+
+    @pytest.mark.parametrize('emotion_level, expected', [(0, False), (1, True), (5, True), (6, False)])
+    def test_emotion_level_bounds(self, emotion_level: int, expected: bool) -> None:
+        assert check_goal('hi', 'happy', emotion_level, 100, 100, 50) is expected
+
+    @pytest.mark.parametrize('pitch, expected', [(49, False), (50, True), (199, True), (200, False)])
+    def test_pitch_bounds(self, pitch: int, expected: bool) -> None:
+        assert check_goal('hi', 'happy', 3, pitch, 100, 50) is expected
+
+    @pytest.mark.parametrize('speed, expected', [(49, False), (50, True), (299, True), (300, False)])
+    def test_speed_bounds(self, speed: int, expected: bool) -> None:
+        assert check_goal('hi', 'happy', 3, 100, speed, 50) is expected
+
+    @pytest.mark.parametrize('volume, expected', [(0, False), (1, True), (100, True), (101, False)])
+    def test_volume_bounds(self, volume: int, expected: bool) -> None:
+        assert check_goal('hi', 'happy', 3, 100, 100, volume) is expected
+
+
+class TestGenerateJtalkCommand:
+    """Tests for generate_jtalk_command()."""
+
+    def test_default_output_file(self) -> None:
+        assert generate_jtalk_command() == ['pw-play', '/tmp/jtalk_output.wav']
+
+    def test_custom_file_path(self) -> None:
+        assert generate_jtalk_command(pathlib.Path('/tmp/x.wav')) == ['pw-play', '/tmp/x.wav']
+
+    def test_options_are_appended(self) -> None:
+        command = generate_jtalk_command(pathlib.Path('/tmp/x.wav'), ['--volume', '50'])
+        assert command == ['pw-play', '/tmp/x.wav', '--volume', '50']
+
+    def test_default_options_are_not_shared_between_calls(self) -> None:
+        first = generate_jtalk_command()
+        first.append('--tainted')
+        assert generate_jtalk_command() == ['pw-play', '/tmp/jtalk_output.wav']
+
+
+class TestLazyLibRoute:
+    """Tests for the lazy LIB_ROUTE module attribute."""
+
+    def test_unknown_attribute_raises(self) -> None:
+        with pytest.raises(AttributeError):
+            jtalk.no_such_attribute
+
+    def test_lib_route_is_exported(self) -> None:
+        assert 'LIB_ROUTE' in jtalk.__all__

--- a/cube_petit_text_to_speech/test/test_jtalk.py
+++ b/cube_petit_text_to_speech/test/test_jtalk.py
@@ -17,12 +17,11 @@
 
 import pathlib
 
-import pytest
-
 from cube_petit_text_to_speech.utils import jtalk
 from cube_petit_text_to_speech.utils.jtalk import adjust_text
 from cube_petit_text_to_speech.utils.jtalk import check_goal
 from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_command
+import pytest
 
 SUFFIX = '〜っ、。'
 

--- a/cube_petit_text_to_speech/test/test_jtalk.py
+++ b/cube_petit_text_to_speech/test/test_jtalk.py
@@ -17,11 +17,12 @@
 
 import pathlib
 
+import pytest
+
 from cube_petit_text_to_speech.utils import jtalk
 from cube_petit_text_to_speech.utils.jtalk import adjust_text
 from cube_petit_text_to_speech.utils.jtalk import check_goal
 from cube_petit_text_to_speech.utils.jtalk import generate_jtalk_command
-import pytest
 
 SUFFIX = '〜っ、。'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[tool.isort]
+profile = "google"
+line_length = 119
+known_third_party = ["launch"]
+
+[tool.autopep8]
+max_line_length = 119
+ignore = "W503"
+aggressive = 2
+
+[tool.yapf]
+based_on_style = "google"
+column_limit = 119
+
+[tool.ruff]
+line-length = 119
+
+[tool.ruff.lint]
+preview = true
+select = ["A", "ANN", "C4", "CPY", "D", "D401", "E", "F", "N", "Q", "W", "SLF"]
+ignore = [
+    "ANN002",
+    "ANN003",
+    "ANN1",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D203",
+    "D212",
+    "D404",
+]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-copyright]
+notice-rgx = "# Copyright \\(c\\) [0-9]{4} SoftBank Corp.\n#\n# Licensed under the Apache License, Version 2.0 \\(the \"License\"\\);\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+
+[tool.ruff.lint.flake8-annotations]
+suppress-dummy-args = true
+
+[tool.ruff.format]
+quote-style = "single"
+line-ending = "lf"


### PR DESCRIPTION
## 概要

純粋ロジック部分へのユニットテスト追加と、CIワークフローの新規導入を行いました(本リポジトリにはこれまでCIがありませんでした)。

## 変更内容

### リファクタリング(挙動は変更なし)
- `cube_petit_text_to_speech/utils/jtalk.py`
  - モジュール読み込み時に `get_package_share_directory()` を実行していた `LIB_ROUTE` を遅延評価化(モジュール `__getattr__` + キャッシュ付き `_lib_route()`)。ROS環境なしでもimport可能になり、既存の `jtalk.LIB_ROUTE` 参照はそのまま動作します
  - `check_goal()` の引数を `Speech.Goal` からプレーンな値に変更(呼び出し側の `speech_action_server.py` がフィールドを渡す形に)
  - `cube_petit_speech_msgs` のimportを使用箇所内へ移動
- `cube_petit_python_api/utils/gpt_client.py`
  - プロンプト組み立てロジック(システムプロンプト既定値・contexts構築)を新規の `gpt_logic.py` に抽出し、`GPTClient` から利用。OpenAI呼び出し部分は変更なし

### テスト追加(57ケース、ROS環境不要で実行可能)
- `cube_petit_text_to_speech/test/test_jtalk.py` — `adjust_text()`(記号・空白・改行・全角記号などの正規化規則、空文字列)、`check_goal()`(各パラメータの境界値)、`generate_jtalk_command()`(コマンドリスト構築)
- `cube_petit_python_api/test/test_gpt_logic.py` — `build_text_contexts()` / `build_image_contexts()` / `DEFAULT_SETTING`
- `cube_petit_python_api/package.xml` に `python3-pytest` の `test_depend` を追加

### CI(新規追加)
- `.github/workflows/ci.yaml` を `cube_petit_scenario` 等の姉妹リポジトリと同構成で作成
  - `linter`: `sbgisen/.github` の `ros2_style` 再利用ワークフロー(PR時)
  - `build`: `ros2-build`(jazzy)。姉妹リポジトリ同様、org secrets(`GISEN_ROBO_GIT` / `KNOWN_HOSTS`)に依存します
  - `release-drafter`
  - `unit-tests`: ubuntu-latest + Python 3.12 で `pytest`(素のrunnerで実行、ROS不要)

## 動作確認

- ROSを一切sourceしない環境で全57テストがpass
  ```
  uv run --no-project --with pytest --with beartype -- python -m pytest cube_petit_text_to_speech/test cube_petit_python_api/test -v
  ```
- ROSなし環境で `cube_petit_text_to_speech.utils.jtalk` のimportが成功することを確認(`LIB_ROUTE` はアクセス時のみ解決)
- ROS環境(実機)で `LIB_ROUTE` が従来と同じパスに解決されること、`gpt_client` がimport可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)