### PR TITLE
jazzy-devel更新時に全PRブランチを自動update-branchする

### DIFF
--- a/.github/workflows/auto_update_prs.yaml
+++ b/.github/workflows/auto_update_prs.yaml
@@ -1,0 +1,40 @@
+name: auto_update_prs
+
+on:
+  push:
+    branches:
+      - jazzy-devel
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update open PR branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Update all open PRs targeting this branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = context.ref.replace("refs/heads/", "");
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              base,
+            });
+            for (const pr of prs) {
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                core.info(`#${pr.number} (${pr.head.ref}): updated`);
+              } catch (e) {
+                core.warning(`#${pr.number} (${pr.head.ref}): ${e.message}`);
+              }
+            }


### PR DESCRIPTION
jazzy-devel に push(=PRマージ)が入るたびに、開いている全PRのブランチへ base の変更を自動で取り込みます(GitHub の「Update branch」ボタン相当をAPIで全PRに実行)。

- rebase ではなくマージ方式(公式 Update branch と同じ)。force-push しないので last-push-approval ルールと衝突しにくい
- コンフリクトで update できないPRは warning を出してスキップ(手動解決が必要)
- 注意: `GITHUB_TOKEN` によるpushはCIを再トリガーしません(GitHubの再帰防止仕様)。update後のPRでCIを回し直したい場合は空コミットpushか手動re-run。必要になったらPATに切り替え可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)