### PR TITLE
cube_petit_python_api: spin不要のCubePetitファサード(3行でしゃべるAPI)

### DIFF
--- a/cube_petit_python_api/README.md
+++ b/cube_petit_python_api/README.md
@@ -1,61 +1,104 @@
-## Build
+# cube_petit_python_api
 
+ROS を知らなくても cube_petit を Python から動かせるパッケージです。
+`rclpy.init()` も `spin()` も不要。3行でしゃべります。
+
+```python
+from cube_petit_python_api import CubePetit
+
+robot = CubePetit()          # デフォルトは cube_petit_orange
+robot.say('こんにちは')       # しゃべり終わるまで待って返ってくる
 ```
-colcon build
+
+裏側では専用ノード + MultiThreadedExecutor がデーモンスレッドで spin しているので、
+利用者が ROS のイベントループを意識する必要はありません。
+
+## セットアップ
+
+ロボット側で cube_petit のスタック(bringup / navigation / facial_animation)が起動していれば、
+同じ ROS ネットワーク上の Python からそのまま使えます。
+
+```bash
+source /opt/ros/jazzy/setup.bash
 source ~/ros/install/setup.bash
+python3
 ```
 
-Check if `ls /home/gisen/ros/install/cube_python_api/lib/python3.10/site-packages/cube_python_api` exist
+## CubePetit の使い方
 
-```
-$ ls /home/gisen/ros/install/cube_python_api/lib/python3.10/site-packages/cube_python_api
-commanders  cube_commander.py  __init__.py  __pycache__  utils
+```python
+from cube_petit_python_api import CubePetit
+
+with CubePetit(robot='cube_petit_orange', timeout=5.0) as robot:
+    robot.say('おはよう', emotion='happy')       # 発話(同期)
+    robot.set_face('happy')                      # 表情変更
+    pose = robot.where_am_i()                    # 地図上の現在位置 (x, y, yaw)
+    robot.move_to('favorite')                    # お気に入りの場所へ移動(非同期)
+    robot.move_to((1.0, 2.0, 0.0), wait=True)    # 座標指定で移動完了まで待つ
+    robot.cancel_move()                          # 移動・パトロール中止
+    robot.remember_place('kitchen')              # 現在位置を場所として保存
 ```
 
-### Usage:Speech
+### メソッド一覧
 
-[Terminal1]
-```
-ros2 launch cube_speech cube_speech.launch.py
-```
+| メソッド | 説明 |
+| --- | --- |
+| `say(text, emotion='normal', wait=True, timeout=None)` | 発話。emotion は `normal` / `happy` / `angry` / `sad` / `shout` |
+| `set_face(expression='normal', timeout=None)` | 表情変更。`normal` / `happy` / `angry` / `sad` / `puzzled` |
+| `move_to(target, wait=False, timeout=None, arrival_timeout=300)` | `'favorite'` / `'patrol'` / `(x, y, yaw)` へ移動 |
+| `cancel_move(timeout=None)` | 移動・パトロールのキャンセル |
+| `where_am_i(timeout=None)` | 地図上の現在位置 `RobotPose(x, y, yaw)`(TF `map`→`base_link`) |
+| `remember_place(name, category='place', timeout=None)` | 現在位置を場所として保存 |
+| `close()` | ノード・スレッドの後始末(`with` 文なら自動) |
 
-[Terminal2]
-```.py
-from rclpy.node import Node
+### 接続先の指定
+
+- コンストラクタ引数: `CubePetit(robot='cube_petit_pink')`
+- 環境変数: `PETIT_ROBOT_NS=cube_petit_pink`(引数が優先)
+- `domain_id=` で ROS_DOMAIN_ID も指定可能
+
+### エラー
+
+ロボットが起動していない・届かないときは、タイムアウト後に
+`CubePetitNotRunning`(「ロボットが起動していないみたい…」)が上がります。
+永遠に固まることはありません。引数がおかしいときは `ValueError`、
+`close()` 後の呼び出しは `CubePetitClosed` です。
+
+### スレッドと寿命
+
+- 1 プロセス内で作成・`close()` を繰り返して OK(インスタンスごとに独立した rclpy コンテキストを持ちます)
+- 各メソッドは複数スレッドから呼んでも安全ですが、`close()` との競合だけは避けてください
+
+## Python すら使わない場合
+
+HTTP で叩ける Web API(`web_interface`)もあります。ROS 環境ゼロのマシンからは
+そちらが便利です。
+
+## 上級者向け(従来のコマンダー)
+
+既存の `CubePetitCommander` / `SpeechCommander` / `GPTChatCommander` はそのまま残っています。
+自分でノードを管理したい場合はこちらを使ってください。
+
+```python
 import rclpy
-from commanders.speech import SpeechCommander
+from rclpy.node import Node
+from cube_petit_python_api.commanders.speech import SpeechCommander
+
 rclpy.init()
 node = Node('test')
-speech_node = SpeechCommander(node)
-speech_node.say("test")
+speech = SpeechCommander(node)
+speech.say('test')
 ```
 
-### Usage:Use Cupe-petit Chat via GPT-4
-Need speech_to_text  `/julius_talk_result`
-Topic can publish like `ros2 topic pub --once /julius_talk_result std_msgs/msg/String "data: 'こんにちは'"`
-Need env `OPENAI_API_KEY`
-Add param `setting_file`: path to setting file
+GPT チャット(要 `OPENAI_API_KEY`):
 
-```.py
-from rclpy.node import Node
-import rclpy
+```python
 from cube_petit_python_api.commanders.gpt_chat import GPTChatCommander
-rclpy.init()
-node = Node('test')
-gpt_chat_node = GPTChatCommander(node)
-gpt_chat_node.chat("こんにちは")
 ```
 
-### Usage:Use just GPT-4
-Need env `OPENAI_API_KEY`
-Add param `setting_file`: path to setting file
+## テスト
 
-```.py
-from rclpy.node import Node
-import rclpy
-from cube_petit_python_api.utils.gpt_client import GPTClient
-rclpy.init()
-node = Node('test')
-gpt_node = GPTClient(self, api_key=`api_key`)
-gpt_node.get_response(こんにちは)
+```bash
+# ROS 環境なしでも動く純ロジックテスト + ROS 環境があればライフサイクルテスト
+python3 -m pytest cube_petit_python_api/test -v
 ```

--- a/cube_petit_python_api/cube_petit_python_api/__init__.py
+++ b/cube_petit_python_api/cube_petit_python_api/__init__.py
@@ -14,15 +14,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Python API for cube_petit.
 
-from cube_petit_python_api import commanders
-from cube_petit_python_api import cube_petit_commander
-from cube_petit_python_api import utils
-from cube_petit_python_api.cube_petit_commander import CubePetitCommander
+All submodules and classes are exported lazily (PEP 562) so that importing
+``cube_petit_python_api`` itself never pulls in ROS dependencies. This keeps
+the pure-logic helpers usable (and testable) in non-ROS environments.
+"""
 
-__all__ = [
-    'commanders',
-    'cube_petit_commander',
-    'utils',
-    'CubePetitCommander'
-]
+import importlib
+import typing
+
+_LAZY_MODULES = ('commanders', 'cube_petit_commander', 'exceptions', 'petit', 'petit_names', 'utils')
+_LAZY_ATTRS = {
+    'CubePetit': ('petit', 'CubePetit'),
+    'CubePetitClosed': ('exceptions', 'CubePetitClosed'),
+    'CubePetitCommander': ('cube_petit_commander', 'CubePetitCommander'),
+    'CubePetitError': ('exceptions', 'CubePetitError'),
+    'CubePetitNotRunning': ('exceptions', 'CubePetitNotRunning'),
+    'RobotPose': ('petit_names', 'RobotPose'),
+}
+
+__all__ = list(_LAZY_MODULES) + list(_LAZY_ATTRS)
+
+
+def __getattr__(name: str) -> typing.Any:  # noqa: ANN401
+    """Import submodules and public classes on first access.
+
+    Args:
+        name: Attribute name.
+
+    Returns:
+        The submodule or class.
+
+    Raises:
+        AttributeError: If the attribute is unknown.
+    """
+    if name in _LAZY_MODULES:
+        return importlib.import_module(f'{__name__}.{name}')
+    if name in _LAZY_ATTRS:
+        module_name, attr = _LAZY_ATTRS[name]
+        return getattr(importlib.import_module(f'{__name__}.{module_name}'), attr)
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/cube_petit_python_api/cube_petit_python_api/exceptions.py
+++ b/cube_petit_python_api/cube_petit_python_api/exceptions.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exceptions for the CubePetit facade API (no ROS dependency)."""
+
+from __future__ import annotations
+
+
+class CubePetitError(RuntimeError):
+    """Base error raised by the CubePetit facade API."""
+
+
+class CubePetitNotRunning(CubePetitError):  # noqa: N818 - friendly name is part of the public API
+    """Raised when the robot stack does not respond within the timeout."""
+
+    def __init__(self, detail: str = '') -> None:
+        """Build a friendly error message.
+
+        Args:
+            detail: Extra context appended to the message (e.g. which interface timed out).
+        """
+        message = ('ロボットが起動していないみたい。'
+                   'cube_petit の起動状態・ネットワーク・namespace 設定を確認してね。')
+        if detail:
+            message = f'{message} ({detail})'
+        super().__init__(message)
+
+
+class CubePetitClosed(CubePetitError):  # noqa: N818 - friendly name is part of the public API
+    """Raised when a method is called on a closed CubePetit instance."""
+
+    def __init__(self) -> None:
+        """Build the error message."""
+        super().__init__('この CubePetit インスタンスはすでに close() されています。新しく作り直してね。')

--- a/cube_petit_python_api/cube_petit_python_api/petit.py
+++ b/cube_petit_python_api/cube_petit_python_api/petit.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CubePetit facade: control the robot from plain Python without touching rclpy.
+
+Example:
+    >>> from cube_petit_python_api import CubePetit
+    >>> with CubePetit() as robot:
+    ...     robot.say('こんにちは')
+
+The facade owns a private node and spins it on a daemon background thread, so
+the caller never needs ``rclpy.init()`` nor ``rclpy.spin()``. Every method is
+synchronous, bounded by a timeout and raises :class:`CubePetitNotRunning`
+(with a Japanese hint) instead of hanging when the robot stack is down.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import typing
+import uuid
+
+from action_msgs.msg import GoalStatus
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.duration import Duration
+from rclpy.executors import ExternalShutdownException
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from std_msgs.msg import String
+from tf2_ros import Buffer
+from tf2_ros import TransformListener
+
+from cube_petit_facial_animation_msgs.msg import FaceExpression
+from cube_petit_navigation_msgs.srv import SavePlace
+from cube_petit_python_api import petit_names
+from cube_petit_python_api.exceptions import CubePetitClosed
+from cube_petit_python_api.exceptions import CubePetitError
+from cube_petit_python_api.exceptions import CubePetitNotRunning
+from cube_petit_python_api.petit_names import RobotPose
+from cube_petit_speech_msgs.action import Speech
+
+_POLL_INTERVAL = 0.05
+
+
+class CubePetit:
+    """Simple synchronous API for cube_petit — no ROS knowledge required.
+
+    The instance is safe to create and close repeatedly within one process
+    (each instance owns its own rclpy context). Methods may be called from
+    multiple threads; the internal executor runs on a daemon thread and stops
+    when :meth:`close` is called or the instance is garbage collected.
+
+    Args:
+        robot: Robot namespace (default: env ``PETIT_ROBOT_NS`` or ``cube_petit_orange``).
+        timeout: Default timeout [s] for discovering robot interfaces.
+        domain_id: Optional ROS domain id. ``None`` uses ``ROS_DOMAIN_ID``.
+    """
+
+    def __init__(self,
+                 robot: typing.Optional[str] = None,
+                 *,
+                 timeout: float = 5.0,
+                 domain_id: typing.Optional[int] = None) -> None:
+        """Start the private node and the background executor thread."""
+        self._namespace = petit_names.resolve_robot_namespace(robot)
+        self._timeout = petit_names.validate_timeout(timeout)
+        self._closed = False
+        self._lock = threading.RLock()
+
+        self._context = rclpy.Context()
+        self._context.init(args=None, domain_id=domain_id)
+        node_name = f'cube_petit_api_{uuid.uuid4().hex[:8]}'
+        self._node: Node = rclpy.create_node(node_name, context=self._context)
+        self._executor = MultiThreadedExecutor(num_threads=2, context=self._context)
+        self._executor.add_node(self._node)
+        self._thread = threading.Thread(target=self._spin, name=node_name, daemon=True)
+        self._thread.start()
+
+        self._speech_client: typing.Optional[ActionClient] = None
+        self._tf_buffer: typing.Optional[Buffer] = None
+        self._tf_listener: typing.Optional[TransformListener] = None
+
+    # =================================================
+    # Lifecycle
+    # =================================================
+
+    def __enter__(self) -> 'CubePetit':
+        """Return self for use as a context manager."""
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Close the facade when leaving a ``with`` block."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Close the facade on garbage collection (best effort)."""
+        try:
+            self.close()
+        except Exception:  # noqa: S110
+            pass
+
+    @property
+    def robot(self) -> str:
+        """The robot namespace this instance talks to."""  # noqa: D401
+        return self._namespace
+
+    def close(self) -> None:
+        """Stop the background executor and release all ROS resources.
+
+        Safe to call multiple times.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._executor.shutdown(timeout_sec=2.0)
+        self._thread.join(timeout=5.0)
+        try:
+            self._node.destroy_node()
+        finally:
+            self._context.try_shutdown()
+
+    # =================================================
+    # Speech
+    # =================================================
+
+    def say(self,
+            text: str,
+            emotion: str = 'normal',
+            *,
+            wait: bool = True,
+            timeout: typing.Optional[float] = None) -> bool:
+        """Make the robot speak.
+
+        Args:
+            text: Text to speak (Japanese OK).
+            emotion: One of ``normal`` / ``happy`` / ``angry`` / ``sad`` / ``shout``
+                (speech server aliases such as ``default`` also work).
+            wait: Wait until the speech finishes. ``False`` returns right after
+                the robot accepts the request.
+            timeout: Timeout [s] for reaching the robot. Defaults to the
+                constructor value.
+
+        Returns:
+            True if the speech succeeded (always True when ``wait=False``).
+
+        Raises:
+            ValueError: If the arguments are invalid.
+            CubePetitNotRunning: If the speech server is unreachable within the timeout.
+            CubePetitError: If the request is rejected or does not finish in time.
+        """
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError('text must be a non-empty string')
+        goal = Speech.Goal()
+        goal.text = text
+        goal.emotion = petit_names.normalize_say_emotion(emotion)
+        goal.emotion_level = 2
+        goal.pitch = 100
+        goal.speed = 100
+        goal.volume = 30
+        timeout = self._resolve_timeout(timeout)
+
+        client = self._get_speech_client()
+        if not client.wait_for_server(timeout_sec=timeout):
+            action_name = petit_names.speech_action_name(self._namespace)
+            raise CubePetitNotRunning(f'speech action {action_name} が見つかりません')
+        goal_handle = self._wait_future(client.send_goal_async(goal), timeout, '発話リクエストの送信')
+        if not goal_handle.accepted:
+            raise CubePetitError('発話リクエストが拒否されました。')
+        if not wait:
+            return True
+        # Speech duration scales with text length; allow a generous bound.
+        result_timeout = max(timeout, 30.0 + 0.5 * len(text))
+        result = self._wait_future(goal_handle.get_result_async(), result_timeout, '発話の完了待ち')
+        return result.status == GoalStatus.STATUS_SUCCEEDED
+
+    # =================================================
+    # Navigation
+    # =================================================
+
+    def move_to(self,
+                target: typing.Union[str, typing.Sequence[float]],
+                *,
+                wait: bool = False,
+                timeout: typing.Optional[float] = None,
+                arrival_timeout: float = 300.0) -> bool:
+        """Send a navigation goal.
+
+        Args:
+            target: ``'favorite'`` / ``'patrol'`` or a map pose ``(x, y, yaw)``.
+            wait: Wait until the robot arrives (or fails).
+            timeout: Timeout [s] for reaching the robot. Defaults to the constructor value.
+            arrival_timeout: Timeout [s] for the arrival when ``wait=True``.
+
+        Returns:
+            True on arrival when ``wait=True``; True right after sending otherwise.
+
+        Raises:
+            ValueError: If the target cannot be interpreted.
+            CubePetitNotRunning: If the navigation stack is unreachable within the timeout.
+            CubePetitError: If ``wait=True`` and the robot does not arrive in time.
+        """
+        goal_text = petit_names.build_move_goal(target)
+        timeout = self._resolve_timeout(timeout)
+        arrival_timeout = petit_names.validate_timeout(arrival_timeout, 'arrival_timeout')
+        self._ensure_open()
+
+        publisher = self._node.create_publisher(String, petit_names.navigation_goal_topic(self._namespace), 10)
+        events: 'typing.List[str]' = []
+        arrived = threading.Event()
+
+        def _on_status(msg: String) -> None:
+            events.append(msg.data)
+            if msg.data in ('arrived', 'failed'):
+                arrived.set()
+
+        subscription = None
+        try:
+            self._wait_for_subscriber(publisher, timeout, petit_names.navigation_goal_topic(self._namespace))
+            if wait:
+                subscription = self._node.create_subscription(String,
+                                                              petit_names.navigation_status_topic(self._namespace),
+                                                              _on_status, 10)
+            publisher.publish(String(data=goal_text))
+            if not wait:
+                return True
+            if not arrived.wait(arrival_timeout):
+                raise CubePetitError(f'{arrival_timeout:.0f}秒待っても移動が完了しませんでした。')
+            return events[-1] == 'arrived'
+        finally:
+            if subscription is not None:
+                self._node.destroy_subscription(subscription)
+            self._node.destroy_publisher(publisher)
+
+    def cancel_move(self, *, timeout: typing.Optional[float] = None) -> None:
+        """Cancel the current navigation or patrol.
+
+        Args:
+            timeout: Timeout [s] for reaching the robot. Defaults to the constructor value.
+
+        Raises:
+            CubePetitNotRunning: If the navigation stack is unreachable within the timeout.
+        """
+        timeout = self._resolve_timeout(timeout)
+        self._ensure_open()
+        publisher = self._node.create_publisher(String, petit_names.navigation_cancel_topic(self._namespace), 10)
+        try:
+            self._wait_for_subscriber(publisher, timeout, petit_names.navigation_cancel_topic(self._namespace))
+            publisher.publish(String(data='cancel'))
+        finally:
+            self._node.destroy_publisher(publisher)
+
+    def where_am_i(self, *, timeout: typing.Optional[float] = None) -> RobotPose:
+        """Return the robot pose on the map frame.
+
+        The pose comes from TF (``map`` -> ``base_link``); this robot does not
+        publish ``amcl_pose``.
+
+        Args:
+            timeout: Timeout [s] for the TF lookup. Defaults to the constructor value.
+
+        Returns:
+            The current pose as ``RobotPose(x, y, yaw)``.
+
+        Raises:
+            CubePetitNotRunning: If no map pose is available within the timeout.
+        """
+        timeout = self._resolve_timeout(timeout)
+        self._ensure_open()
+        with self._lock:
+            if self._tf_buffer is None:
+                self._tf_buffer = Buffer()
+                self._tf_listener = TransformListener(self._tf_buffer, self._node)
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                transform = self._tf_buffer.lookup_transform('map',
+                                                             'base_link',
+                                                             rclpy.time.Time(),
+                                                             timeout=Duration(seconds=0.0))
+                translation = transform.transform.translation
+                rotation = transform.transform.rotation
+                yaw = petit_names.yaw_from_quaternion(rotation.x, rotation.y, rotation.z, rotation.w)
+                return RobotPose(x=translation.x, y=translation.y, yaw=yaw)
+            except Exception:  # noqa: PERF203 - tf2 raises several lookup error types
+                if time.monotonic() >= deadline:
+                    raise CubePetitNotRunning('地図上の位置(TF map->base_link)が取得できません。'
+                                              'ナビゲーションが起動しているか確認してね') from None
+                time.sleep(_POLL_INTERVAL)
+
+    def remember_place(self, name: str, category: str = 'place', *, timeout: typing.Optional[float] = None) -> bool:
+        """Save the current position as a named place.
+
+        Args:
+            name: Place name (e.g. ``kitchen``).
+            category: Place category. Defaults to ``place``.
+            timeout: Timeout [s] for reaching the robot. Defaults to the constructor value.
+
+        Returns:
+            True if the place was saved.
+
+        Raises:
+            ValueError: If the name is empty.
+            CubePetitNotRunning: If the save place service is unreachable within the timeout.
+        """
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError('name must be a non-empty string')
+        timeout = self._resolve_timeout(timeout)
+        self._ensure_open()
+        client = self._node.create_client(SavePlace, petit_names.save_place_service(self._namespace))
+        try:
+            if not client.wait_for_service(timeout_sec=timeout):
+                service_name = petit_names.save_place_service(self._namespace)
+                raise CubePetitNotRunning(f'service {service_name} が見つかりません')
+            request = SavePlace.Request()
+            request.name = name
+            request.category = category
+            response = self._wait_future(client.call_async(request), timeout, '場所の保存')
+            return response.success
+        finally:
+            self._node.destroy_client(client)
+
+    # =================================================
+    # Face
+    # =================================================
+
+    def set_face(self, expression: str = 'normal', *, timeout: typing.Optional[float] = None) -> None:
+        """Change the facial expression.
+
+        Args:
+            expression: One of ``normal`` / ``happy`` / ``angry`` / ``sad`` / ``puzzled``.
+            timeout: Timeout [s] for reaching the robot. Defaults to the constructor value.
+
+        Raises:
+            ValueError: If the expression is unknown.
+            CubePetitNotRunning: If the facial animation node is unreachable within the timeout.
+        """
+        expression = petit_names.normalize_face_expression(expression)
+        timeout = self._resolve_timeout(timeout)
+        self._ensure_open()
+        publisher = self._node.create_publisher(FaceExpression, petit_names.face_command_topic(self._namespace), 10)
+        try:
+            self._wait_for_subscriber(publisher, timeout, petit_names.face_command_topic(self._namespace))
+            publisher.publish(FaceExpression(expression=expression))
+        finally:
+            self._node.destroy_publisher(publisher)
+
+    # =================================================
+    # Internals
+    # =================================================
+
+    def _spin(self) -> None:
+        """Spin the private executor until shutdown (runs on the daemon thread)."""
+        try:
+            self._executor.spin()
+        except (ExternalShutdownException, RuntimeError):
+            pass
+
+    def _ensure_open(self) -> None:
+        """Raise if the instance has been closed.
+
+        Raises:
+            CubePetitClosed: If :meth:`close` has been called.
+        """
+        if self._closed:
+            raise CubePetitClosed()
+
+    def _resolve_timeout(self, timeout: typing.Optional[float]) -> float:
+        """Return the validated timeout, falling back to the constructor default.
+
+        Args:
+            timeout: Timeout [s] or ``None``.
+
+        Returns:
+            Timeout in seconds.
+        """
+        self._ensure_open()
+        return self._timeout if timeout is None else petit_names.validate_timeout(timeout)
+
+    def _get_speech_client(self) -> ActionClient:
+        """Return the (cached) speech action client."""
+        with self._lock:
+            self._ensure_open()
+            if self._speech_client is None:
+                self._speech_client = ActionClient(self._node, Speech, petit_names.speech_action_name(self._namespace))
+            return self._speech_client
+
+    def _wait_future(self, future: 'rclpy.task.Future', timeout: float, what: str) -> typing.Any:  # noqa: ANN401
+        """Wait for an rclpy future completed by the background executor.
+
+        Args:
+            future: Future returned by an async rclpy call.
+            timeout: Maximum wait time [s].
+            what: Human readable description for error messages.
+
+        Returns:
+            The future result.
+
+        Raises:
+            CubePetitNotRunning: If the future does not complete within the timeout.
+        """
+        event = threading.Event()
+        future.add_done_callback(lambda _future: event.set())
+        if not event.wait(timeout):
+            future.cancel()
+            raise CubePetitNotRunning(f'{what}が{timeout:.1f}秒以内に完了しませんでした')
+        return future.result()
+
+    def _wait_for_subscriber(self, publisher: 'rclpy.publisher.Publisher', timeout: float, topic: str) -> None:
+        """Wait until at least one subscriber is connected to the publisher.
+
+        Args:
+            publisher: Publisher to check.
+            timeout: Maximum wait time [s].
+            topic: Topic name for the error message.
+
+        Raises:
+            CubePetitNotRunning: If nobody subscribes within the timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while publisher.get_subscription_count() == 0:
+            if time.monotonic() >= deadline:
+                raise CubePetitNotRunning(f'topic {topic} の購読者が見つかりません')
+            time.sleep(_POLL_INTERVAL)

--- a/cube_petit_python_api/cube_petit_python_api/petit_names.py
+++ b/cube_petit_python_api/cube_petit_python_api/petit_names.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure helpers for the CubePetit facade (no ROS dependency).
+
+This module holds all logic that does not need ROS: resource name building,
+argument validation and small geometry helpers. Keeping it ROS-free lets the
+unit tests run without a ROS environment.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import typing
+
+DEFAULT_ROBOT = 'cube_petit_orange'
+ROBOT_NS_ENV = 'PETIT_ROBOT_NS'
+
+_NS_PATTERN = re.compile(r'[A-Za-z][A-Za-z0-9_]*(?:/[A-Za-z][A-Za-z0-9_]*)*')
+
+#: Friendly emotion aliases accepted by :func:`normalize_say_emotion`,
+#: mapped to the emotion names understood by the speech action server (jtalk).
+SAY_EMOTIONS: typing.Dict[str, str] = {
+    'normal': 'default',
+    'default': 'default',
+    'happy': 'happiness',
+    'happiness': 'happiness',
+    'angry': 'anger',
+    'anger': 'anger',
+    'sad': 'sadness',
+    'sadness': 'sadness',
+    'shout': 'shout',
+}
+
+#: Expressions accepted by the facial animation node (FaceExpression.msg).
+FACE_EXPRESSIONS: typing.Tuple[str, ...] = ('normal', 'happy', 'angry', 'sad', 'puzzled')
+
+#: Keyword goals understood by navigation_api_node.
+MOVE_KEYWORDS: typing.Tuple[str, ...] = ('favorite', 'patrol')
+
+
+class RobotPose(typing.NamedTuple):
+    """Robot pose on the map frame (2D)."""
+
+    x: float
+    y: float
+    yaw: float
+
+
+def resolve_robot_namespace(robot: typing.Optional[str] = None) -> str:
+    """Resolve the robot namespace from an argument or the environment.
+
+    Priority: explicit argument > ``PETIT_ROBOT_NS`` environment variable > default.
+
+    Args:
+        robot: Robot namespace such as ``cube_petit_orange``. Leading/trailing
+            slashes are tolerated. ``None`` falls back to the environment.
+
+    Returns:
+        Namespace without leading/trailing slashes.
+
+    Raises:
+        ValueError: If the resolved namespace is empty or contains invalid characters.
+    """
+    if robot is None:
+        robot = os.environ.get(ROBOT_NS_ENV) or DEFAULT_ROBOT
+    if not isinstance(robot, str):
+        raise ValueError(f'robot must be a string, got {type(robot).__name__}')
+    namespace = robot.strip().strip('/')
+    if not namespace or not _NS_PATTERN.fullmatch(namespace):
+        raise ValueError(f'Invalid robot namespace: {robot!r}')
+    return namespace
+
+
+def speech_action_name(namespace: str) -> str:
+    """Build the fully qualified speech action name.
+
+    Args:
+        namespace: Robot namespace (no slashes around it).
+
+    Returns:
+        Action name such as ``/cube_petit_orange/speech_action_server``.
+    """
+    return f'/{namespace}/speech_action_server'
+
+
+def face_command_topic(namespace: str) -> str:
+    """Build the facial expression command topic name.
+
+    Args:
+        namespace: Robot namespace.
+
+    Returns:
+        Topic name such as ``/cube_petit_orange/facial_expression/expression_command``.
+    """
+    return f'/{namespace}/facial_expression/expression_command'
+
+
+def navigation_goal_topic(namespace: str) -> str:
+    """Build the navigation goal topic name.
+
+    Args:
+        namespace: Robot namespace.
+
+    Returns:
+        Topic name such as ``/cube_petit_orange/navigation/goal``.
+    """
+    return f'/{namespace}/navigation/goal'
+
+
+def navigation_cancel_topic(namespace: str) -> str:
+    """Build the navigation cancel topic name.
+
+    Args:
+        namespace: Robot namespace.
+
+    Returns:
+        Topic name such as ``/cube_petit_orange/navigation/cancel``.
+    """
+    return f'/{namespace}/navigation/cancel'
+
+
+def navigation_status_topic(namespace: str) -> str:
+    """Build the navigation status topic name.
+
+    Args:
+        namespace: Robot namespace.
+
+    Returns:
+        Topic name such as ``/cube_petit_orange/navigation/status``.
+    """
+    return f'/{namespace}/navigation/status'
+
+
+def save_place_service(namespace: str) -> str:
+    """Build the save place service name.
+
+    Args:
+        namespace: Robot namespace.
+
+    Returns:
+        Service name such as ``/cube_petit_orange/navigation/save_place``.
+    """
+    return f'/{namespace}/navigation/save_place'
+
+
+def normalize_say_emotion(emotion: str) -> str:
+    """Map a friendly emotion alias to a speech server emotion name.
+
+    Args:
+        emotion: One of the keys of :data:`SAY_EMOTIONS` (e.g. ``normal``, ``happy``).
+
+    Returns:
+        Emotion name for the speech action goal (e.g. ``default``, ``happiness``).
+
+    Raises:
+        ValueError: If the emotion is unknown.
+    """
+    if not isinstance(emotion, str) or emotion.lower() not in SAY_EMOTIONS:
+        raise ValueError(f'Unknown emotion: {emotion!r}. Available: {sorted(SAY_EMOTIONS)}')
+    return SAY_EMOTIONS[emotion.lower()]
+
+
+def normalize_face_expression(expression: str) -> str:
+    """Validate a facial expression name.
+
+    Args:
+        expression: One of :data:`FACE_EXPRESSIONS`.
+
+    Returns:
+        Normalized (lower-cased) expression name.
+
+    Raises:
+        ValueError: If the expression is unknown.
+    """
+    if not isinstance(expression, str) or expression.lower() not in FACE_EXPRESSIONS:
+        raise ValueError(f'Unknown expression: {expression!r}. Available: {list(FACE_EXPRESSIONS)}')
+    return expression.lower()
+
+
+def build_move_goal(target: typing.Union[str, typing.Sequence[float]]) -> str:
+    """Build a navigation goal string for navigation_api_node.
+
+    Args:
+        target: Either a keyword (``favorite`` / ``patrol``), a ``pose:x,y,yaw``
+            string, or a sequence of three numbers ``(x, y, yaw)``.
+
+    Returns:
+        Goal string such as ``favorite`` or ``pose:1.0,2.0,0.0``.
+
+    Raises:
+        ValueError: If the target cannot be interpreted.
+    """
+    if isinstance(target, str):
+        text = target.strip()
+        if text in MOVE_KEYWORDS:
+            return text
+        if text.startswith('pose:'):
+            body = text.split(':', 1)[1]
+            values = body.split(',')
+            if len(values) == 3:
+                try:
+                    x, y, yaw = (float(value) for value in values)
+                except ValueError:
+                    raise ValueError(f'Invalid pose goal: {target!r}') from None
+                return f'pose:{x},{y},{yaw}'
+        raise ValueError(f'Unknown move target: {target!r}. Use {list(MOVE_KEYWORDS)} or (x, y, yaw).')
+    if isinstance(target, (tuple, list)) and len(target) == 3:
+        try:
+            x, y, yaw = (float(value) for value in target)
+        except (TypeError, ValueError):
+            raise ValueError(f'Pose must contain three numbers, got {target!r}') from None
+        return f'pose:{x},{y},{yaw}'
+    raise ValueError(f'Unknown move target: {target!r}. Use {list(MOVE_KEYWORDS)} or (x, y, yaw).')
+
+
+def validate_timeout(timeout: typing.Union[int, float], name: str = 'timeout') -> float:
+    """Validate a timeout value.
+
+    Args:
+        timeout: Timeout in seconds. Must be a positive finite number.
+        name: Argument name used in the error message.
+
+    Returns:
+        The timeout as ``float``.
+
+    Raises:
+        ValueError: If the timeout is not a positive finite number.
+    """
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise ValueError(f'{name} must be a number, got {type(timeout).__name__}')
+    value = float(timeout)
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f'{name} must be a positive finite number, got {timeout!r}')
+    return value
+
+
+def yaw_from_quaternion(x: float, y: float, z: float, w: float) -> float:
+    """Extract the yaw angle from a quaternion.
+
+    Args:
+        x: Quaternion x.
+        y: Quaternion y.
+        z: Quaternion z.
+        w: Quaternion w.
+
+    Returns:
+        Yaw angle in radians within ``[-pi, pi]``.
+    """
+    return math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))

--- a/cube_petit_python_api/package.xml
+++ b/cube_petit_python_api/package.xml
@@ -18,9 +18,13 @@
   <depend>move_base_msgs</depend>
   <depend>python3-numpy</depend>
   <depend>python-transforms3d-pip</depend> -->
+  <depend>cube_petit_facial_animation_msgs</depend>
+  <depend>cube_petit_navigation_msgs</depend>
+  <depend>cube_petit_speech_msgs</depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_ros_py</depend>
   <!-- <depend>tf</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/cube_petit_python_api/test/conftest.py
+++ b/cube_petit_python_api/test/conftest.py
@@ -14,14 +14,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Make gpt_logic importable without installing the package.
+"""Make the package importable without installing it.
 
-Note: the utils directory itself is added to sys.path because
-``cube_petit_python_api/__init__.py`` imports ROS dependencies at module
-level; importing via the package path would require a ROS environment.
+The package root is added to ``sys.path`` so ``cube_petit_python_api`` can be
+imported directly; its ``__init__`` is lazy (PEP 562), so pure-logic modules
+such as ``petit_names`` work without a ROS environment.
+
+The utils directory itself is also added because ``test_gpt_logic`` imports
+``gpt_logic`` as a top-level module (it predates the lazy ``__init__``).
 """
 
 from pathlib import Path
 import sys
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'cube_petit_python_api' / 'utils'))

--- a/cube_petit_python_api/test/test_petit_lifecycle.py
+++ b/cube_petit_python_api/test/test_petit_lifecycle.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lifecycle tests for the CubePetit facade (requires rclpy, no robot).
+
+Skipped automatically when rclpy or the message packages are unavailable
+(e.g. the plain-Python unit-tests CI job). In the colcon test environment
+these run without any robot: every call must fail fast with
+CubePetitNotRunning instead of hanging.
+
+Note: a plain ``pytest.importorskip`` at module level aborts the whole
+directory collection with this pytest/plugin combination, hence the
+try/except + ``skipif`` guard.
+"""
+
+import time
+
+import pytest
+
+try:
+    import rclpy  # noqa: F401
+
+    import cube_petit_facial_animation_msgs  # noqa: F401
+    import cube_petit_navigation_msgs  # noqa: F401
+    from cube_petit_python_api.exceptions import CubePetitClosed
+    from cube_petit_python_api.exceptions import CubePetitNotRunning
+    from cube_petit_python_api.petit import CubePetit
+    import cube_petit_speech_msgs  # noqa: F401
+    _SKIP_REASON = ''
+except ImportError as error:  # pragma: no cover - exercised only without ROS
+    _SKIP_REASON = f'ROS environment not available: {error}'
+
+pytestmark = pytest.mark.skipif(bool(_SKIP_REASON), reason=_SKIP_REASON)
+
+# Isolated ROS domain so a robot running on the same machine/network cannot
+# interfere with the "stack down" assumption.
+_TEST_DOMAIN_ID = 77
+_TEST_ROBOT = 'cube_petit_test_no_robot'
+_TIMEOUT = 1.0
+
+
+def _make_robot() -> 'CubePetit':
+    return CubePetit(robot=_TEST_ROBOT, timeout=_TIMEOUT, domain_id=_TEST_DOMAIN_ID)
+
+
+class TestNoRobot:
+    """Every API call must raise CubePetitNotRunning quickly when nothing is running."""
+
+    def test_say_raises_within_timeout(self) -> None:
+        start = time.monotonic()
+        with _make_robot() as robot:
+            with pytest.raises(CubePetitNotRunning):
+                robot.say('こんにちは')
+        assert time.monotonic() - start < _TIMEOUT + 10.0
+
+    def test_move_where_face_raise(self) -> None:
+        with _make_robot() as robot:
+            with pytest.raises(CubePetitNotRunning):
+                robot.move_to('favorite')
+            with pytest.raises(CubePetitNotRunning):
+                robot.where_am_i()
+            with pytest.raises(CubePetitNotRunning):
+                robot.set_face('happy')
+            with pytest.raises(CubePetitNotRunning):
+                robot.cancel_move()
+            with pytest.raises(CubePetitNotRunning):
+                robot.remember_place('kitchen')
+
+    def test_invalid_arguments_fail_fast(self) -> None:
+        with _make_robot() as robot:
+            with pytest.raises(ValueError):
+                robot.say('')
+            with pytest.raises(ValueError):
+                robot.say('hello', emotion='sleepy')
+            with pytest.raises(ValueError):
+                robot.move_to('unknown_place')
+            with pytest.raises(ValueError):
+                robot.set_face('crying')
+
+
+class TestLifecycle:
+    """Create/close cycles must be leak-free and repeatable in one process."""
+
+    def test_init_close_twice(self) -> None:
+        for _ in range(2):
+            robot = _make_robot()
+            assert robot.robot == _TEST_ROBOT
+            with pytest.raises(CubePetitNotRunning):
+                robot.where_am_i(timeout=0.5)
+            robot.close()
+
+    def test_close_is_idempotent(self) -> None:
+        robot = _make_robot()
+        robot.close()
+        robot.close()
+
+    def test_methods_after_close_raise(self) -> None:
+        robot = _make_robot()
+        robot.close()
+        with pytest.raises(CubePetitClosed):
+            robot.say('hello')
+        with pytest.raises(CubePetitClosed):
+            robot.where_am_i()
+
+    def test_spin_thread_stops_after_close(self) -> None:
+        robot = _make_robot()
+        thread = robot._thread  # noqa: SLF001
+        assert thread.is_alive()
+        robot.close()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()

--- a/cube_petit_python_api/test/test_petit_names.py
+++ b/cube_petit_python_api/test/test_petit_names.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the pure-logic helpers of the CubePetit facade (no ROS required)."""
+
+import math
+
+import pytest
+
+from cube_petit_python_api import petit_names
+from cube_petit_python_api.exceptions import CubePetitError
+from cube_petit_python_api.exceptions import CubePetitNotRunning
+
+
+class TestResolveRobotNamespace:
+    """Tests for resolve_robot_namespace()."""
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(petit_names.ROBOT_NS_ENV, raising=False)
+        assert petit_names.resolve_robot_namespace() == 'cube_petit_orange'
+
+    def test_env_variable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(petit_names.ROBOT_NS_ENV, 'cube_petit_pink')
+        assert petit_names.resolve_robot_namespace() == 'cube_petit_pink'
+
+    def test_argument_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(petit_names.ROBOT_NS_ENV, 'cube_petit_pink')
+        assert petit_names.resolve_robot_namespace('cube_petit_orange') == 'cube_petit_orange'
+
+    def test_strips_slashes(self) -> None:
+        assert petit_names.resolve_robot_namespace('/cube_petit_orange/') == 'cube_petit_orange'
+
+    @pytest.mark.parametrize('bad', ['', '/', 'has space', '0start', 'a//b', 'にほんご'])
+    def test_invalid(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            petit_names.resolve_robot_namespace(bad)
+
+    def test_non_string(self) -> None:
+        with pytest.raises(ValueError):
+            petit_names.resolve_robot_namespace(123)  # type: ignore[arg-type]
+
+
+class TestNameBuilders:
+    """Tests for the fully-qualified name builders."""
+
+    def test_speech_action_name(self) -> None:
+        assert petit_names.speech_action_name('cube_petit_orange') == '/cube_petit_orange/speech_action_server'
+
+    def test_face_command_topic(self) -> None:
+        assert petit_names.face_command_topic('ns') == '/ns/facial_expression/expression_command'
+
+    def test_navigation_topics(self) -> None:
+        assert petit_names.navigation_goal_topic('ns') == '/ns/navigation/goal'
+        assert petit_names.navigation_cancel_topic('ns') == '/ns/navigation/cancel'
+        assert petit_names.navigation_status_topic('ns') == '/ns/navigation/status'
+        assert petit_names.save_place_service('ns') == '/ns/navigation/save_place'
+
+
+class TestNormalizeSayEmotion:
+    """Tests for normalize_say_emotion()."""
+
+    @pytest.mark.parametrize(('alias', 'expected'), [
+        ('normal', 'default'),
+        ('happy', 'happiness'),
+        ('angry', 'anger'),
+        ('sad', 'sadness'),
+        ('shout', 'shout'),
+        ('HAPPY', 'happiness'),
+        ('default', 'default'),
+    ])
+    def test_alias(self, alias: str, expected: str) -> None:
+        assert petit_names.normalize_say_emotion(alias) == expected
+
+    def test_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            petit_names.normalize_say_emotion('sleepy')
+
+
+class TestNormalizeFaceExpression:
+    """Tests for normalize_face_expression()."""
+
+    @pytest.mark.parametrize('expression', ['normal', 'happy', 'angry', 'sad', 'puzzled'])
+    def test_valid(self, expression: str) -> None:
+        assert petit_names.normalize_face_expression(expression) == expression
+
+    def test_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            petit_names.normalize_face_expression('crying')
+
+
+class TestBuildMoveGoal:
+    """Tests for build_move_goal()."""
+
+    @pytest.mark.parametrize('keyword', ['favorite', 'patrol'])
+    def test_keyword(self, keyword: str) -> None:
+        assert petit_names.build_move_goal(keyword) == keyword
+
+    def test_pose_tuple(self) -> None:
+        assert petit_names.build_move_goal((1, 2.5, 0)) == 'pose:1.0,2.5,0.0'
+
+    def test_pose_string(self) -> None:
+        assert petit_names.build_move_goal('pose:1.0,2.0,0.5') == 'pose:1.0,2.0,0.5'
+
+    @pytest.mark.parametrize('bad', ['kitchen', 'pose:1,2', 'pose:a,b,c', (1, 2), (1, 2, 'x'), None, 42])
+    def test_invalid(self, bad: object) -> None:
+        with pytest.raises(ValueError):
+            petit_names.build_move_goal(bad)  # type: ignore[arg-type]
+
+
+class TestValidateTimeout:
+    """Tests for validate_timeout()."""
+
+    def test_valid(self) -> None:
+        assert petit_names.validate_timeout(3) == 3.0
+        assert petit_names.validate_timeout(0.5) == 0.5
+
+    @pytest.mark.parametrize('bad', [0, -1, float('inf'), float('nan'), 'fast', None, True])
+    def test_invalid(self, bad: object) -> None:
+        with pytest.raises(ValueError):
+            petit_names.validate_timeout(bad)  # type: ignore[arg-type]
+
+
+class TestYawFromQuaternion:
+    """Tests for yaw_from_quaternion()."""
+
+    def test_identity(self) -> None:
+        assert petit_names.yaw_from_quaternion(0.0, 0.0, 0.0, 1.0) == pytest.approx(0.0)
+
+    def test_quarter_turn(self) -> None:
+        half = math.sin(math.pi / 4.0)
+        assert petit_names.yaw_from_quaternion(0.0, 0.0, half, half) == pytest.approx(math.pi / 2.0)
+
+
+class TestExceptions:
+    """Tests for the friendly exceptions."""
+
+    def test_not_running_message(self) -> None:
+        error = CubePetitNotRunning('speech が見つかりません')
+        assert 'ロボットが起動していないみたい' in str(error)
+        assert 'speech が見つかりません' in str(error)
+        assert isinstance(error, CubePetitError)
+
+    def test_lazy_package_import_is_ros_free(self) -> None:
+        import cube_petit_python_api
+        assert 'CubePetit' in cube_petit_python_api.__all__


### PR DESCRIPTION
## 何を・なぜ

「ROSわからん人がAPI叩いたら話す、とかしてほしい。でもspinを回さないといけない縛りが課題」への回答です。
`cube_petit_python_api` に **CubePetit ファサードクラス**を追加し、rclpy の init も spin も知らずに3行でロボットを動かせるようにしました。

```python
from cube_petit_python_api import CubePetit

robot = CubePetit()      # デフォルト namespace: cube_petit_orange(env PETIT_ROBOT_NS でも指定可)
robot.say('こんにちは')   # しゃべり終わるまで待って返ってくる
```

## 変更内容

- **`petit.py` — CubePetit クラス**(新規)
  - 専用ノード + MultiThreadedExecutor を**デーモンスレッドで spin** → 利用者は spin 不要
  - 同期メソッド: `say(text, emotion)` / `set_face(expression)` / `move_to('favorite'|'patrol'|(x,y,yaw), wait=)` / `cancel_move()` / `where_am_i()` / `remember_place(name)`
  - `where_am_i()` は **TF (map→base_link)** ベース(この機体は amcl_pose が出ないため)
  - ロボット未起動時は全メソッドがタイムアウト後に `CubePetitNotRunning`(「ロボットが起動していないみたい…」)を送出。**永遠に固まらない**
  - インスタンスごとに独立した rclpy Context を持つので、1プロセス内で生成/`close()` を繰り返してもリークしない。context manager 対応
- **`petit_names.py` / `exceptions.py`**(新規): 名前解決・引数検証などの純ロジック(ROS import なし=非ROS環境でテスト可能)
- **`__init__.py`**: PEP 562 の遅延 import に変更。`import cube_petit_python_api` だけなら ROS 不要に(既存の `CubePetitCommander` 等の import 経路は維持)
- **テスト**: 純ロジック56件(ROS不要)+ ライフサイクル7件(rclpy必要・**ロボット不要**、ROS_DOMAIN_ID=77で隔離。非ROS環境では自動skip)
- **README**: 3行ハローワールド中心に刷新(Web API = web_interface がゼロROSの代替である旨も記載)
- package.xml に msgs / tf2_ros_py 依存を追加

既存の commanders / utils には手を入れていません(追加のみ)。

### 読む順番

1. `cube_petit_python_api/cube_petit_python_api/petit.py` — 核心。`CubePetit.__init__`(スレッドでspin)と `close()`、あとは各メソッドが「接続確認→送信→タイムアウト付き待ち」の同じ形
2. `test/test_petit_lifecycle.py` — 「ロボットなしで叩くと全部フレンドリーに失敗する」仕様がそのまま読めます
3. `petit_names.py` / `test_petit_names.py` / `exceptions.py` / README — 純ロジックとドキュメント、流し読みOK
4. `__init__.py` / `conftest.py` / `package.xml` — 機械的変更

## 動作確認

- [x] CI(lint / build / unit tests)が緑
- [ ] 実機確認(未確認のため `needs-robot-test` 付き)

体内PC(スタック停止状態)で確認済み:
- ハローワールドが3秒でフレンドリーエラー(ハングしない)
- 同一プロセスで生成→close を2周してもスレッド残留なし(MainThreadのみ)
- ROS環境あり: 63 passed / ROS環境なし: 56 passed, 7 skipped

### 実機確認手順(コピペで動くこと。理想は petit-test 1コマンド)

```bash
petit-test cube_petit_ros 90  # ← PR番号に読み替え
# ロボットのスタックが起動している状態で:
python3 -c "
from cube_petit_python_api import CubePetit
with CubePetit() as robot:
    robot.say('こんにちは、プチです')
    robot.set_face('happy')
    print(robot.where_am_i())
"
# 期待: しゃべる→顔がhappy→地図上の座標が出力される
```

## かわいさ・振る舞いへの影響

このPR自体はロボットの挙動を変えません(新しい呼び出し口の追加のみ)。
ただし、誰でも3行で「しゃべらせる・表情を変える」ができるようになるので、
デモや来客対応でプチにセリフを言わせる遊びがやりやすくなります。
`say()` の emotion(happy/sad/angry/shout)がjtalkの声色にそのまま乗ります。

## レビューポイント

- `close()` の後始末の順序(executor.shutdown → thread.join → destroy_node → context.try_shutdown)に穴がないか
- `move_to(wait=True)` は `navigation/status` の `arrived`/`failed` を待つ設計。パトロール中に叩いたときの挙動はnavigation_api_node側仕様(already running なら無視)に依存します
- 発話完了待ちの上限を `max(timeout, 30 + 0.5×文字数)` 秒にしたのが妥当か

🤖 Generated with [Claude Code](https://claude.com/claude-code)
