### PR TITLE
bringup: 顔色のデフォルトを個体のホスト名から導出(全個体オレンジ固定だった不具合)

### DIFF
--- a/cube_petit_bringup/launch/cube_petit_bringup.launch.py
+++ b/cube_petit_bringup/launch/cube_petit_bringup.launch.py
@@ -120,9 +120,14 @@ def generate_launch_description() -> LaunchDescription:
     hostname = socket.gethostname()
     namespace = hostname.replace('-', '_')
     args.append(DeclareLaunchArgument('cube_petit_host_name', default_value=namespace))
+    # Individuals are named cube_petit_<color> (e.g. cube_petit_pink), so the
+    # face color can be derived from the hostname instead of being fixed to
+    # orange for every unit. Falls back to orange for hosts that don't follow
+    # that naming convention (dev machines, etc.).
+    face_color_default = (namespace[len('cube_petit_'):] if namespace.startswith('cube_petit_') else 'orange')
     args.append(
         DeclareLaunchArgument('face_color',
-                              default_value='orange',
+                              default_value=face_color_default,
                               description='Color for the faceBox (pink, orange, blue, green, yellow, purple)'))
 
     ordered_sequence = OpaqueFunction(function=launch_in_order)


### PR DESCRIPTION
## 何を・なぜ

pinkでbringupを起動したところ、顔がオレンジ色で表示された。

`cube_petit_bringup.launch.py`の`face_color`引数のデフォルト値が、全個体共通で
固定文字列`'orange'`になっていた。すぐ上の行で`cube_petit_host_name`のデフォルトは
`socket.gethostname()`から正しく個体名を導出しているのに、`face_color`だけそれを
使わず決め打ちだった(おそらくorangeが唯一の個体だった頃の名残)。

個体名は`cube_petit_<色名>`(`cube_petit_pink`、`cube_petit_yellow`等)という命名規則なので、
既に導出済みの`namespace`から色名部分を切り出してデフォルトにした。この命名規則に
従わないホスト名(開発機など)では従来どおり`'orange'`にフォールバックする。

## 実機確認手順

```bash
# pinkで(color引数を明示指定せずに)
ros2 launch cube_petit_bringup cube_petit_bringup.launch.py
# 顔がpink色で表示されることを確認
```

## ロボットの振る舞いへの影響

あり: 個体名がcube_petit_<色>規則に従うロボットは、`color`引数を明示指定しなくても
自分の色の顔になる(従来はorange固定だった)。`color:=xxx`を明示指定している既存の
起動コマンド・自動起動設定には影響なし。

## 読む順番ガイド

1. `cube_petit_bringup/launch/cube_petit_bringup.launch.py`の`face_color`デフォルト値の変更のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
