### PR TITLE
facial_animation: Chromeの初回起動ダイアログを抑制

### DIFF
--- a/cube_petit_facial_animation/cube_petit_facial_animation/animation.py
+++ b/cube_petit_facial_animation/cube_petit_facial_animation/animation.py
@@ -66,7 +66,7 @@ class Chrome():
         # can terminate the whole group instead of only the top-level process.
         self._p = subprocess.Popen([
             'google-chrome', '--new-window', '--start-fullscreen', '--disable-features=Translate', '--guest',
-            '--kiosk', '--start-maximized', '--password-store=basic', '--no-default-browser-check',
+            '--kiosk', '--start-maximized', '--password-store=basic', '--no-default-browser-check', '--no-first-run',
             '--hide-crash-restore-bubble', f'--user-data-dir={chrome_user_data_dir}', html_path
         ],
                                    start_new_session=True)


### PR DESCRIPTION
## 何を・なぜ

pinkのbringup再起動後、顔の画面に「ようこそ Google Chrome へ」ダイアログが出て
手動でOKを押さないと先に進めなかった。

`--guest`モードは毎回使い捨てのプロファイルになるため、`--no-first-run`を付けていないと
初回起動ダイアログが起動のたびに出てしまう。1行追加で解消。

## 実機確認手順

```bash
ros2 run cube_petit_facial_animation animation.py --ros-args -p color:=pink
# フルスクリーンのkioskウィンドウがダイアログ無しで即座に顔を表示することを確認
```

## ロボットの振る舞いへの影響

顔の起動が毎回ダイアログでブロックされなくなる(見た目・動作は変更なし)。

## 読む順番ガイド

1. `cube_petit_facial_animation/cube_petit_facial_animation/animation.py`のChrome起動引数に
   `--no-first-run`を1つ追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
