### PR TITLE
navigation_api: pose:ゴールが実行中のナビゲーションを横取りできるように

### DIFF
--- a/cube_petit_navigation/cube_petit_navigation/navigation/cube_petit_navigation_commander.py
+++ b/cube_petit_navigation/cube_petit_navigation/navigation/cube_petit_navigation_commander.py
@@ -24,6 +24,7 @@ from action_msgs.msg import GoalStatus
 from geometry_msgs.msg import PoseStamped
 from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
+from rclpy.action.client import ClientGoalHandle
 from rclpy.node import Node
 from rclpy.task import Future
 
@@ -88,13 +89,19 @@ class CubePetitNavigationCommander:
             self._result = None
 
         result_future = goal_handle.get_result_async()
-        result_future.add_done_callback(self._on_result)
+        result_future.add_done_callback(lambda f: self._on_result(f, goal_handle))
 
-    def _on_result(self, future: Future) -> None:
+    def _on_result(self, future: Future, goal_handle: ClientGoalHandle) -> None:
         result = future.result()
         status = result.status
 
         with self._lock:
+            if self._goal_handle is not goal_handle:
+                # A newer goal has already preempted this one (e.g. rapid
+                # pose: updates while chasing a moving target). This result
+                # belongs to the old, superseded goal -- ignore it so it
+                # can't clobber the newer goal's in-progress state.
+                return
             self._result = status == GoalStatus.STATUS_SUCCEEDED
             self._goal_handle = None
 

--- a/cube_petit_navigation/cube_petit_navigation/navigation_api_node.py
+++ b/cube_petit_navigation/cube_petit_navigation/navigation_api_node.py
@@ -158,6 +158,19 @@ class NavigationApiNode(Node):
         text = msg.data.strip()
         self.get_logger().info(f'Received navigation goal: {text}')
 
+        if text.startswith('pose:'):
+            # pose: goals are allowed to preempt an in-progress navigation or
+            # patrol, unlike favorite/patrol below. This is needed for use
+            # cases like chasing another robot's live position, where the
+            # target is re-sent frequently and each update must take over
+            # immediately instead of being silently dropped because a
+            # (now-stale) previous pose goal was still "running".
+            if self._patrol_controller.is_running():
+                self._patrol_controller.cancel()
+            pose = self._parse_pose(text)
+            self._start_navigation(pose)
+            return
+
         if self._nav_commander.is_navigating() or self._patrol_controller.is_running():
             self.get_logger().info('Navigation already running')
             return
@@ -170,10 +183,6 @@ class NavigationApiNode(Node):
         elif text == 'patrol':
             self._patrol_controller.start()
             self._publish_status('patrolling')
-
-        elif text.startswith('pose:'):
-            pose = self._parse_pose(text)
-            self._start_navigation(pose)
 
         else:
             self.get_logger().warning(f'Unknown goal: {text}')


### PR DESCRIPTION
## 何を・なぜ

ROSConJP向けの「追いかけっこ」デモ準備から。相手ロボットの生きている位置を追い続けるには
`navigation/goal`に`pose:x,y,yaw`を高頻度で送り続ける必要があるが、`_on_goal`は
既にナビゲーション実行中だと新しいゴールを黙って無視していた(favorite/patrol用に
入れていたガードが、更新の激しいpose:ユースケースにも一律にかかっていた)。

`pose:`ゴールだけは既存のナビ/patrolを横取りできるようにした。favorite/patrolは
従来どおり実行中の割り込みを受け付けない。

あわせて、この変更で表面化する競合状態を`CubePetitNavigationCommander`側で防止:
頻繁にゴールを差し替えると、古いゴールの結果コールバックが新しいゴール受理後に
遅れて届くことがあり、放置すると新しいゴールの状態を上書きしてしまう。
goal_handleの同一性を結果コールバックまで追跡し、現在追跡中のゴール以外の結果は無視する。

## 実機確認手順

```bash
# navigation_api_node起動中に、poseゴールを連続で素早く送る
ros2 topic pub --once /navigation/goal std_msgs/msg/String "data: 'pose:1.0,0.0,0.0'"
sleep 1
ros2 topic pub --once /navigation/goal std_msgs/msg/String "data: 'pose:2.0,0.0,0.0'"
# 2回目のゴールが1回目を中断して即座に反映されることを確認(以前は無視されていた)
ros2 topic echo /navigation/status
# 頻繁な切り替えを繰り返しても status が変な状態(navigating のまま固まる等)にならないことを確認
```

## ロボットの振る舞いへの影響

`pose:`ゴールの割り込み挙動が変わる(以前: 無視される→今回: 割り込んで新ゴールに向かう)。
favorite/patrolの挙動に変更なし。

## 読む順番ガイド

1. `navigation_api_node.py`の`_on_goal`: `pose:`の分岐を先頭に移動、割り込み許可
2. `cube_petit_navigation_commander.py`: `goal_handle`の同一性チェックを結果コールバックに追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
